### PR TITLE
feat: stackable filter+sort views, multi-column sort, refresh preserves view

### DIFF
--- a/crates/kensa-engine/src/lib.rs
+++ b/crates/kensa-engine/src/lib.rs
@@ -31,11 +31,11 @@ mod stats;
 mod types;
 
 use crate::column::{infer_column_dtype, ColumnData};
-use crate::errors::KensaError;
+use crate::errors::{KensaError, KensaResult};
 use crate::filter::{apply_filters, FilterOp};
 use crate::types::{
     ColumnStats, DatasetInfo, DataSlice, ExamplePair, FilterSpec, FrequencyEntry, HistogramBin,
-    QuickInsight,
+    QuickInsight, SortSpec,
 };
 use napi::bindgen_prelude::*;
 use rayon::prelude::*;
@@ -61,10 +61,22 @@ impl DataFrame {
 
 /// The engine exposed to Node.js. Holds at most one dataset at a time — open a
 /// new file and the previous one is dropped.
+///
+/// Filter and sort state are tracked separately from `view_indices` so
+/// they compose. The previous design only stored the materialized
+/// `view_indices` and rebuilt it from a single source (filter OR sort)
+/// on every call — applying a sort would wipe an active filter and
+/// vice versa. Now `active_filters` and `active_sorts` are durable;
+/// `view_indices` is recomputed by `recompute_view` from both. That
+/// matches the Python backend's behaviour (which has always composed
+/// `view_filters` + `view_sort` inside `current_view`) and lets the
+/// webview keep filter+sort layered as the user expects.
 #[napi]
 pub struct DataEngine {
     df: Option<Arc<DataFrame>>,
     view_indices: Option<Vec<usize>>,
+    active_filters: Vec<FilterSpec>,
+    active_sorts: Vec<SortSpec>,
     current_path: Option<String>,
 }
 
@@ -72,7 +84,13 @@ pub struct DataEngine {
 impl DataEngine {
     #[napi(constructor)]
     pub fn new() -> Self {
-        Self { df: None, view_indices: None, current_path: None }
+        Self {
+            df: None,
+            view_indices: None,
+            active_filters: Vec::new(),
+            active_sorts: Vec::new(),
+            current_path: None,
+        }
     }
 
     /// Load a CSV or TSV file. `delimiter` defaults to comma, `encoding`
@@ -94,7 +112,7 @@ impl DataEngine {
             .map_err(to_napi)?;
         let info = build_info(&df);
         self.df = Some(Arc::new(df));
-        self.view_indices = None;
+        self.reset_view_state();
         self.current_path = Some(path);
         Ok(info)
     }
@@ -106,7 +124,7 @@ impl DataEngine {
         let df = parquet_reader::read_parquet(&path).map_err(to_napi)?;
         let info = build_info(&df);
         self.df = Some(Arc::new(df));
-        self.view_indices = None;
+        self.reset_view_state();
         self.current_path = Some(path);
         Ok(info)
     }
@@ -118,7 +136,7 @@ impl DataEngine {
         let df = excel_reader::read_excel(&path, sheet.as_deref()).map_err(to_napi)?;
         let info = build_info(&df);
         self.df = Some(Arc::new(df));
-        self.view_indices = None;
+        self.reset_view_state();
         self.current_path = Some(path);
         Ok(info)
     }
@@ -130,7 +148,7 @@ impl DataEngine {
         let df = jsonl_reader::read_jsonl(&path).map_err(to_napi)?;
         let info = build_info(&df);
         self.df = Some(Arc::new(df));
-        self.view_indices = None;
+        self.reset_view_state();
         self.current_path = Some(path);
         Ok(info)
     }
@@ -190,34 +208,41 @@ impl DataEngine {
         Ok(insights)
     }
 
-    /// Sort by one column in the current view. Replaces `view_indices` with a
-    /// freshly computed permutation. Stable sort.
+    /// Apply a multi-column sort. Pass an empty vec to clear the sort
+    /// without touching the active filter. Replaces the previous
+    /// single-column `sort(col, asc)` API; multi-key callers list the
+    /// keys in priority order (primary first). Filters are preserved
+    /// across this call by `recompute_view`.
     #[napi]
-    pub fn sort(&mut self, col_index: u32, ascending: bool) -> Result<()> {
-        let df = self.require_df()?;
-        let indices = sort::sort_indices(df, col_index as usize, ascending)
-            .map_err(to_napi)?;
-        self.view_indices = Some(indices);
+    pub fn sort(&mut self, sorts: Vec<SortSpec>) -> Result<()> {
+        self.active_sorts = sorts;
+        self.recompute_view().map_err(to_napi)?;
         Ok(())
     }
 
     /// Clear any active sort/filter view and return to dataset order.
     #[napi]
     pub fn reset_view(&mut self) -> Result<()> {
-        self.view_indices = None;
+        self.reset_view_state();
         Ok(())
     }
 
-    /// Apply a list of filter predicates (AND-combined). Returns the number of
-    /// rows that passed the filter.
+    /// Apply a list of filter predicates (AND-combined). Returns the number
+    /// of rows that pass after both filter and the currently-active sort
+    /// have been composed via `recompute_view`. Sorts are preserved
+    /// across this call (the previous design wiped them).
     #[napi]
     pub fn filter(&mut self, filters: Vec<FilterSpec>) -> Result<u32> {
-        let df = self.require_df()?;
-        let predicates: Vec<FilterOp> = filters.iter().map(FilterOp::from_spec).collect();
-        let indices = apply_filters(df, &predicates).map_err(to_napi)?;
-        let n = indices.len();
-        self.view_indices = Some(indices);
-        Ok(n as u32)
+        self.active_filters = filters;
+        self.recompute_view().map_err(to_napi)?;
+        // After recompute_view, view_indices reflects the composed view.
+        // When both filter and sort are empty we leave it as None and
+        // surface `df.row_count` so the UI's row count agrees.
+        Ok(match (&self.df, &self.view_indices) {
+            (_, Some(v)) => v.len() as u32,
+            (Some(df), None) => df.row_count as u32,
+            _ => 0,
+        })
     }
 
     /// Substring search within a column. Returns indices into the current
@@ -305,7 +330,7 @@ impl DataEngine {
     #[napi]
     pub fn clear(&mut self) {
         self.df = None;
-        self.view_indices = None;
+        self.reset_view_state();
         self.current_path = None;
     }
 }
@@ -313,6 +338,54 @@ impl DataEngine {
 // -- helpers ------------------------------------------------------------------
 
 impl DataEngine {
+    /// Drop both the materialized `view_indices` and the inputs that
+    /// produced it (`active_filters`, `active_sorts`). Used by every
+    /// `load_*` entry point and the public `reset_view` so the engine
+    /// can never end up with stale filter/sort state pointing at a
+    /// freshly-loaded dataset whose columns may not even exist anymore.
+    fn reset_view_state(&mut self) {
+        self.view_indices = None;
+        self.active_filters.clear();
+        self.active_sorts.clear();
+    }
+
+    /// Recompute `view_indices` from the current filter + sort state.
+    ///   1. If both are empty → `view_indices = None` (raw dataset order).
+    ///   2. Otherwise build the filtered indices first (or `0..row_count`
+    ///      when there's no filter).
+    ///   3. Then run a stable multi-key sort over those indices.
+    ///
+    /// This is the only place that writes to `view_indices` after a load,
+    /// which guarantees filter+sort always compose: applying a filter
+    /// preserves the active sort order, and applying a sort preserves
+    /// the active filter. Errors propagate unchanged so the napi caller
+    /// sees a typed `KensaError` (e.g. on out-of-range column indices).
+    fn recompute_view(&mut self) -> KensaResult<()> {
+        if self.active_filters.is_empty() && self.active_sorts.is_empty() {
+            self.view_indices = None;
+            return Ok(());
+        }
+        let df = match &self.df {
+            Some(arc) => arc.as_ref(),
+            None => return Ok(()),
+        };
+        let mut indices: Vec<usize> = if self.active_filters.is_empty() {
+            (0..df.row_count).collect()
+        } else {
+            let predicates: Vec<FilterOp> = self
+                .active_filters
+                .iter()
+                .map(FilterOp::from_spec)
+                .collect();
+            apply_filters(df, &predicates)?
+        };
+        if !self.active_sorts.is_empty() {
+            sort::sort_indices_multi(df, &mut indices, &self.active_sorts)?;
+        }
+        self.view_indices = Some(indices);
+        Ok(())
+    }
+
     /// Borrow the currently-loaded `DataFrame` or return a clean napi error.
     ///
     /// We deliberately spell out the `match` + `arc.as_ref()` path instead

--- a/crates/kensa-engine/src/sort.rs
+++ b/crates/kensa-engine/src/sort.rs
@@ -4,68 +4,115 @@
 //!
 //! Missing values always sort last, regardless of direction. This matches
 //! Pandas' `na_position='last'` default.
+//!
+//! Two entry points:
+//!   - `sort_indices` — single-key sort starting from full dataset order.
+//!     Kept for the existing single-column callers and for tests.
+//!   - `sort_indices_multi` — composite stable sort on a *given* indices
+//!     vec, keyed on a chain of `(column, ascending)` pairs. The starting
+//!     indices are the caller's: passing the result of `apply_filters` lets
+//!     filter and multi-sort compose. The first key is primary; ties
+//!     fall through to the second key; etc. Stability of the sort means
+//!     rows that are equal on every key preserve the caller's original
+//!     order — important when that order itself comes from a filter.
 
 use crate::column::ColumnData;
 use crate::errors::{KensaError, KensaResult};
+use crate::types::SortSpec;
 use crate::DataFrame;
 use std::cmp::Ordering;
 
+/// Single-key convenience wrapper kept around for the existing test
+/// suite. Production callers go through `sort_indices_multi` directly
+/// — the engine's `sort()` method now accepts a multi-key spec
+/// list, so this helper is `cfg(test)` to keep production binaries
+/// from carrying a now-unused symbol.
+#[cfg(test)]
 pub fn sort_indices(df: &DataFrame, col_index: usize, ascending: bool) -> KensaResult<Vec<usize>> {
-    // `Vec::get` instead of `if bounds { err }; vec[col_index]`. Same
-    // semantics but the raw index expression is gone, which CodeQL's
-    // Rust extractor requires to clear `rust/access-invalid-pointer`.
-    let col = df
-        .columns
-        .get(col_index)
-        .ok_or(KensaError::ColumnIndexOutOfRange {
-            index: col_index,
-            count: df.columns.len(),
-        })?;
-    // Row indices (0..row_count). By construction these are valid
-    // indices into every column data vector of the owning DataFrame
-    // because `DataFrame::new` derives `row_count` from the columns'
-    // length. The comparator closures below use `v.get(a)` /
-    // `v.get(b)` to turn that implicit invariant into something the
-    // borrow-checker and static analyzers can see directly.
     let mut indices: Vec<usize> = (0..df.row_count).collect();
+    let spec = SortSpec {
+        column_index: col_index as u32,
+        ascending,
+    };
+    sort_indices_multi(df, &mut indices, std::slice::from_ref(&spec))?;
+    Ok(indices)
+}
+
+/// Multi-key composite stable sort. `indices` is mutated in place: pass
+/// the result of `apply_filters` to compose filter + sort, or pass
+/// `(0..row_count).collect()` to sort the full dataset.
+///
+/// All `SortSpec.column_index` values are validated up front; an
+/// out-of-range index yields `KensaError::ColumnIndexOutOfRange` and
+/// the indices vec is left untouched. We capture validated `&ColumnData`
+/// references in a small `keys` vec and have the comparator iterate
+/// that — no raw indexing inside the closure, which keeps CodeQL's
+/// Rust extractor happy and removes any per-comparison bounds-check.
+pub fn sort_indices_multi(
+    df: &DataFrame,
+    indices: &mut [usize],
+    sorts: &[SortSpec],
+) -> KensaResult<()> {
+    if sorts.is_empty() {
+        return Ok(());
+    }
+    let keys: Vec<(&ColumnData, bool)> = sorts
+        .iter()
+        .map(|s| {
+            let col_idx = s.column_index as usize;
+            df.columns
+                .get(col_idx)
+                .map(|col| (col, s.ascending))
+                .ok_or(KensaError::ColumnIndexOutOfRange {
+                    index: col_idx,
+                    count: df.columns.len(),
+                })
+        })
+        .collect::<KensaResult<_>>()?;
+
+    indices.sort_by(|&a, &b| {
+        for &(col, ascending) in &keys {
+            let order = cmp_at(col, a, b, ascending);
+            if order != Ordering::Equal {
+                return order;
+            }
+        }
+        Ordering::Equal
+    });
+    Ok(())
+}
+
+/// Compare two row positions on a single column, honouring missing-last
+/// and the `ascending` flag. Used by the multi-key comparator above
+/// once per key per pair, so it stays branch-free per dtype.
+fn cmp_at(col: &ColumnData, a: usize, b: usize, ascending: bool) -> Ordering {
     match col {
         ColumnData::Int64(v) => {
-            indices.sort_by(|&a, &b| {
-                let va = v.get(a).copied().unwrap_or(None);
-                let vb = v.get(b).copied().unwrap_or(None);
-                cmp_opt(va, vb, ascending)
-            });
+            let va = v.get(a).copied().unwrap_or(None);
+            let vb = v.get(b).copied().unwrap_or(None);
+            cmp_opt(va, vb, ascending)
         }
         ColumnData::Float64(v) => {
-            indices.sort_by(|&a, &b| {
-                let va = v.get(a).copied().unwrap_or(None).filter(|x| !x.is_nan());
-                let vb = v.get(b).copied().unwrap_or(None).filter(|x| !x.is_nan());
-                cmp_opt_partial(va, vb, ascending)
-            });
+            let va = v.get(a).copied().unwrap_or(None).filter(|x| !x.is_nan());
+            let vb = v.get(b).copied().unwrap_or(None).filter(|x| !x.is_nan());
+            cmp_opt_partial(va, vb, ascending)
         }
         ColumnData::Utf8(v) => {
-            indices.sort_by(|&a, &b| {
-                let va = v.get(a).and_then(Option::as_ref);
-                let vb = v.get(b).and_then(Option::as_ref);
-                cmp_opt(va, vb, ascending)
-            });
+            let va = v.get(a).and_then(Option::as_ref);
+            let vb = v.get(b).and_then(Option::as_ref);
+            cmp_opt(va, vb, ascending)
         }
         ColumnData::Boolean(v) => {
-            indices.sort_by(|&a, &b| {
-                let va = v.get(a).copied().unwrap_or(None);
-                let vb = v.get(b).copied().unwrap_or(None);
-                cmp_opt(va, vb, ascending)
-            });
+            let va = v.get(a).copied().unwrap_or(None);
+            let vb = v.get(b).copied().unwrap_or(None);
+            cmp_opt(va, vb, ascending)
         }
         ColumnData::DateTime(v) => {
-            indices.sort_by(|&a, &b| {
-                let va = v.get(a).copied().unwrap_or(None);
-                let vb = v.get(b).copied().unwrap_or(None);
-                cmp_opt(va, vb, ascending)
-            });
+            let va = v.get(a).copied().unwrap_or(None);
+            let vb = v.get(b).copied().unwrap_or(None);
+            cmp_opt(va, vb, ascending)
         }
     }
-    Ok(indices)
 }
 
 fn cmp_opt<T: Ord + Copy>(a: Option<T>, b: Option<T>, ascending: bool) -> Ordering {
@@ -116,5 +163,39 @@ mod tests {
         );
         let idx = sort_indices(&df, 0, false).unwrap();
         assert_eq!(idx, vec![2, 0, 1]);
+    }
+
+    #[test]
+    fn multi_key_uses_secondary_as_tiebreaker() {
+        // Group by `region` ASC, then within each region by `revenue`
+        // DESC. Rows 0/2 share region "EU"; row 2 has higher revenue
+        // so it should land first within the group.
+        let df = DataFrame::new(
+            vec![
+                ColumnData::Utf8(vec![
+                    Some("EU".into()),
+                    Some("US".into()),
+                    Some("EU".into()),
+                    Some("US".into()),
+                ]),
+                ColumnData::Int64(vec![Some(10), Some(50), Some(30), Some(20)]),
+            ],
+            vec!["region".into(), "revenue".into()],
+        );
+        let mut indices: Vec<usize> = (0..4).collect();
+        let sorts = vec![
+            SortSpec {
+                column_index: 0,
+                ascending: true,
+            },
+            SortSpec {
+                column_index: 1,
+                ascending: false,
+            },
+        ];
+        sort_indices_multi(&df, &mut indices, &sorts).unwrap();
+        // EU group first (ASC on region), revenue 30 before 10 (DESC).
+        // Then US group, revenue 50 before 20.
+        assert_eq!(indices, vec![2, 0, 1, 3]);
     }
 }

--- a/crates/kensa-engine/src/types.rs
+++ b/crates/kensa-engine/src/types.rs
@@ -85,6 +85,17 @@ pub struct FilterSpec {
     pub case_insensitive: Option<bool>,
 }
 
+/// One key in a multi-column sort. Listed in priority order on the
+/// engine call: the first entry is the primary sort key, the second is
+/// the tiebreaker, and so on. Stable across keys — rows that are equal
+/// on every key keep their relative input order, which matters when
+/// the input is itself the output of a filter.
+#[napi(object)]
+pub struct SortSpec {
+    pub column_index: u32,
+    pub ascending: bool,
+}
+
 #[napi(object)]
 pub struct ExamplePair {
     pub input: String,

--- a/src/extension/dataRouter.ts
+++ b/src/extension/dataRouter.ts
@@ -162,19 +162,28 @@ export class DataRouter {
     return backend.getAllInsights();
   }
 
-  async applySort(sort: SortSpec | null): Promise<void> {
+  async applySort(sorts: SortSpec[]): Promise<void> {
     if (this.mode === 'viewing' && this.rustEngine) {
-      if (sort) this.rustEngine.sort(sort.columnIndex, sort.ascending);
-      else this.rustEngine.resetView();
+      // The Rust engine now composes filter + sort internally, so we
+      // pass the empty list through rather than calling `resetView`
+      // (which would also wipe any active filter). The engine treats
+      // an empty `sorts` list as "no sort", recomputing `view_indices`
+      // from just the active filters.
+      this.rustEngine.sort(sorts.map((s) => ({ columnIndex: s.columnIndex, ascending: s.ascending })));
       return;
     }
-    // Editing mode: set the TRANSIENT view sort on the Python backend. It's
-    // a view-level mask, not a step, so clearing it instantly restores the
-    // unsorted order without touching the step history.
+    // Editing mode: push the multi-key sort to the Python backend as a
+    // transient view-level sort. It's not a Pandas step, so clearing
+    // the list instantly restores unsorted order without rewriting
+    // the step history.
     const backend = await this.kernelManager.ensureBackend();
-    const columnName =
-      sort && this.lastSlice ? this.lastSlice.columns[sort.columnIndex]?.name ?? '' : '';
-    await backend.setViewSort(sort && columnName ? { column: columnName, ascending: sort.ascending } : null);
+    const payload = sorts
+      .map((s) => ({
+        column: this.lastSlice?.columns[s.columnIndex]?.name ?? '',
+        ascending: s.ascending
+      }))
+      .filter((s) => s.column !== '');
+    await backend.setViewSort(payload);
   }
 
   async applyFilter(filters: FilterSpec[]): Promise<void> {

--- a/src/extension/pythonBackend.ts
+++ b/src/extension/pythonBackend.ts
@@ -38,7 +38,7 @@ type BackendCommand =
       new: Array<Array<string | null>>;
     }
   | { cmd: 'set_view_filters'; filters: Array<{ column: string; op: string; value?: string }> }
-  | { cmd: 'set_view_sort'; sort: { column: string; ascending: boolean } | null };
+  | { cmd: 'set_view_sort'; sorts: Array<{ column: string; ascending: boolean }> };
 
 /** A preview slice chunk returned by Python. Mirrors DataSlice but adds a
  *  per-cell `changedMask` the grid uses to paint diff highlights for only
@@ -216,8 +216,10 @@ export class PythonBackend {
 
   /** Replace the transient view sort on the Python side. Pass `null` to
    *  clear. Returns a fresh first-page slice. */
-  async setViewSort(sort: { column: string; ascending: boolean } | null): Promise<DataSlice> {
-    return (await this.request({ cmd: 'set_view_sort', sort })) as DataSlice;
+  async setViewSort(
+    sorts: Array<{ column: string; ascending: boolean }>
+  ): Promise<DataSlice> {
+    return (await this.request({ cmd: 'set_view_sort', sorts })) as DataSlice;
   }
 
   async applyCode(code: string, step: OperationStep): Promise<DataSlice> {

--- a/src/extension/rustBridge.ts
+++ b/src/extension/rustBridge.ts
@@ -62,7 +62,7 @@ export interface RustDataEngine {
   getSlice(start: number, end: number): DataSliceDTO;
   getColumnStats(columnIndex: number): ColumnStatsDTO;
   getAllQuickInsights(): QuickInsightDTO[];
-  sort(columnIndex: number, ascending: boolean): void;
+  sort(sorts: Array<{ columnIndex: number; ascending: boolean }>): void;
   resetView(): void;
   filter(
     filters: Array<{

--- a/src/extension/webviewProvider.ts
+++ b/src/extension/webviewProvider.ts
@@ -286,7 +286,7 @@ export class WebviewProvider implements vscode.Disposable {
         }
 
         case 'applySort': {
-          await router.applySort(msg.sort);
+          await router.applySort(msg.sorts);
           const slice = await router.getSlice(0, DEFAULT_PAGE_SIZE);
           this.post(entry, { type: 'dataSlice', slice });
           // The webview clears its cached insights whenever a fresh slice
@@ -391,17 +391,39 @@ export class WebviewProvider implements vscode.Disposable {
             `[kensa] refresh requested for source=${router.currentSource?.kind ?? 'none'}`
           );
           await router.refresh();
-          const slice = await router.getSlice(0, DEFAULT_PAGE_SIZE);
+          // Pull a slice once so `lastSlice` is populated — it's used by
+          // applyFilter / applySort to translate column indices into
+          // names for the Python backend. Without this priming step the
+          // re-application below would silently drop every filter when
+          // running in editing mode.
+          let slice = await router.getSlice(0, DEFAULT_PAGE_SIZE);
           entry.lastSlice = slice;
+          // Re-apply the view the user had before the refresh, so the
+          // chip and the data shown stay in sync. We accept the lists
+          // from the webview rather than tracking them on the extension
+          // side because the webview is the source of truth for the
+          // active view.
+          //
+          // If a filter references a column that no longer exists (e.g.
+          // the user re-ran the upstream cell and dropped it), the
+          // backend silently skips that filter at apply time — better
+          // than failing the whole refresh.
+          const filters = msg.filters ?? [];
+          const sorts = msg.sorts ?? [];
+          if (filters.length > 0) {
+            await router.applyFilter(filters);
+          }
+          if (sorts.length > 0) {
+            await router.applySort(sorts);
+          }
+          if (filters.length > 0 || sorts.length > 0) {
+            slice = await router.getSlice(0, DEFAULT_PAGE_SIZE);
+            entry.lastSlice = slice;
+          }
           this.post(entry, { type: 'dataSlice', slice });
           // Also refresh the column insights since the data shape may have
           // changed completely (different rows, different stats).
-          router
-            .getAllInsights()
-            .then((insights) => this.post(entry, { type: 'allColumnInsights', insights }))
-            .catch((err) =>
-              this.output.appendLine(`[kensa] post-refresh insights failed: ${String(err)}`)
-            );
+          this.refreshInsights(entry);
           break;
         }
 

--- a/src/python/kensa_helpers.py
+++ b/src/python/kensa_helpers.py
@@ -40,11 +40,16 @@ except Exception:  # pragma: no cover
 class KensaState:
     """Holds the original DF plus the current working copy + applied steps.
 
-    `view_filters` and `view_sort` are transient, webview-driven view controls
+    `view_filters` and `view_sorts` are transient, webview-driven view controls
     that get re-applied as a mask on top of `working_df` every time the grid
     asks for a slice. They are NOT part of the step history — clearing them
     returns the view to the committed working_df. That's how clearing a
-    quick filter instantly restores hidden rows in Editing mode."""
+    quick filter instantly restores hidden rows in Editing mode.
+
+    `view_sorts` is a list (in priority order, primary first) rather than
+    a single sort, so the user can build a multi-key sort like
+    "by region ASC, then revenue DESC" — Pandas honours that natively
+    via `sort_values(by=[...], ascending=[...])`."""
 
     def __init__(self) -> None:
         self.orig_df: Optional["pd.DataFrame"] = None
@@ -53,7 +58,7 @@ class KensaState:
         self.file_path: Optional[str] = None
         self.steps: List[Dict[str, Any]] = []
         self.view_filters: List[Dict[str, Any]] = []
-        self.view_sort: Optional[Dict[str, Any]] = None
+        self.view_sorts: List[Dict[str, Any]] = []
 
     def replay(self) -> None:
         """Re-apply all stored steps to the original DF."""
@@ -65,19 +70,27 @@ class KensaState:
         self.working_df = df
 
     def viewed_df(self) -> Optional["pd.DataFrame"]:
-        """The working_df after the transient view filters + sort are applied.
+        """The working_df after the transient view filters + sorts are applied.
         Used by every slice/stats query so the view stays in sync with the
-        webview's `activeFilters` without mutating the step history."""
+        webview's `activeFilters` / `activeSorts` without mutating the step
+        history. Filter is applied first so the sort runs over the smaller
+        post-filter row set."""
         if self.working_df is None:
             return None
         df = self.working_df
         if self.view_filters:
             df = _apply_view_filters(df, self.view_filters)
-        if self.view_sort:
-            col = self.view_sort.get("column")
-            asc = bool(self.view_sort.get("ascending", True))
-            if col is not None and col in df.columns:
-                df = df.sort_values(by=col, ascending=asc, na_position="last")
+        if self.view_sorts:
+            cols: List[str] = []
+            ascs: List[bool] = []
+            for s in self.view_sorts:
+                col = s.get("column")
+                if col is None or col not in df.columns:
+                    continue
+                cols.append(col)
+                ascs.append(bool(s.get("ascending", True)))
+            if cols:
+                df = df.sort_values(by=cols, ascending=ascs, na_position="last")
         return df
 
 
@@ -169,7 +182,7 @@ def load_file(path: str, kind: str, options: Optional[Dict[str, Any]] = None) ->
     STATE.file_path = path
     STATE.steps = []
     STATE.view_filters = []
-    STATE.view_sort = None
+    STATE.view_sorts = []
     return dataset_info(df)
 
 
@@ -187,7 +200,7 @@ def load_pickle(path: str) -> Dict[str, Any]:
     STATE.file_path = path
     STATE.steps = []
     STATE.view_filters = []
-    STATE.view_sort = None
+    STATE.view_sorts = []
     return dataset_info(df)
 
 
@@ -269,9 +282,14 @@ def set_view_filters(filters: List[Dict[str, Any]]) -> Dict[str, Any]:
     return get_slice(0, 500)
 
 
-def set_view_sort(sort: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-    """Replace the transient view sort. Pass `None` (or {}) to clear."""
-    STATE.view_sort = sort if sort else None
+def set_view_sorts(sorts: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Replace the transient multi-key view sort with the given priority
+    list (primary first). Pass `[]` to clear. Each entry is
+    `{"column": str, "ascending": bool}`. Unknown columns are silently
+    dropped at apply time inside `viewed_df` rather than raising — the
+    webview can hold a stale column reference briefly while a refresh
+    is in flight, and we don't want that to surface as an error toast."""
+    STATE.view_sorts = list(sorts or [])
     return get_slice(0, 500)
 
 
@@ -660,7 +678,7 @@ DISPATCH: Dict[str, Any] = {
     "export_parquet": lambda msg: export_parquet(msg["path"]),
     "diff": lambda msg: diff_against(msg["prev"], msg["new"]),
     "set_view_filters": lambda msg: set_view_filters(msg.get("filters") or []),
-    "set_view_sort": lambda msg: set_view_sort(msg.get("sort")),
+    "set_view_sort": lambda msg: set_view_sorts(msg.get("sorts") or []),
 }
 
 

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -23,7 +23,7 @@ export type WebviewToExtensionMessage =
   | { type: 'requestDataSlice'; start: number; end: number }
   | { type: 'requestColumnStats'; columnIndex: number }
   | { type: 'requestAllColumnInsights' }
-  | { type: 'applySort'; sort: SortSpec | null }
+  | { type: 'applySort'; sorts: SortSpec[] }
   | { type: 'applyFilter'; filters: FilterSpec[] }
   | { type: 'previewOperation'; operationId: string; parameters: Record<string, unknown> }
   | { type: 'applyOperation'; operationId: string; parameters: Record<string, unknown> }
@@ -34,7 +34,13 @@ export type WebviewToExtensionMessage =
   | { type: 'executeCustomCode'; code: string }
   | { type: 'searchColumns'; query: string }
   | { type: 'switchMode'; mode: EditorMode }
-  | { type: 'refreshSource' }
+  // The webview ships its current view state along with the refresh
+  // request so the extension can re-apply filters + sorts to the
+  // freshly-loaded backend after the underlying data is re-read.
+  // Without this, refreshing a filtered view silently desyncs: the
+  // chip says "1 filter active" while the data shown is unfiltered
+  // because the Python/Rust state was reset by the reload.
+  | { type: 'refreshSource'; filters?: FilterSpec[]; sorts?: SortSpec[] }
   | { type: 'requestPreviewSlice'; start: number; end: number }
   | { type: 'inferFlashFill'; columnIndex: number; examples: Array<{ input: string; output: string }> };
 

--- a/src/webview/components/ColumnHeader.tsx
+++ b/src/webview/components/ColumnHeader.tsx
@@ -46,14 +46,21 @@ export function ColumnHeader({
     s.insights.find((i) => i.columnIndex === column.index) ?? null
   );
   const allFilters = useKensaStore((s) => s.activeFilters);
-  const activeSort = useKensaStore((s) =>
-    s.activeSort?.columnIndex === column.index ? s.activeSort : null
-  );
+  // Pull this column's sort entry plus its priority slot in the global
+  // sort list. The badge in the menu reads "↑ 2" for the secondary
+  // sort, "↑ 3" for the tertiary, etc. — same convention Excel uses
+  // for multi-column sort. `null` when this column isn't sorted.
+  const activeSort = useKensaStore((s) => {
+    const idx = s.activeSorts.findIndex((x) => x.columnIndex === column.index);
+    const sort = idx === -1 ? undefined : s.activeSorts[idx];
+    if (idx === -1 || !sort) return null;
+    return { sort, priority: idx + 1, total: s.activeSorts.length };
+  });
   const addOrReplaceColumnFilter = useKensaStore((s) => s.addOrReplaceColumnFilter);
   const addFilter = useKensaStore((s) => s.addFilter);
   const removeColumnFilter = useKensaStore((s) => s.removeColumnFilter);
   const removeFilterAt = useKensaStore((s) => s.removeFilterAt);
-  const applySort = useKensaStore((s) => s.applySort);
+  const toggleSortStore = useKensaStore((s) => s.toggleSort);
 
   // Filters active on *this* column specifically, with their global index
   // preserved so `removeFilterAt` can target the exact instance to drop.
@@ -64,10 +71,18 @@ export function ColumnHeader({
         .filter(({ filter }) => filter.columnIndex === column.index),
     [allFilters, column.index]
   );
-  const quickFilter = columnFilters.find(({ filter }) =>
-    QUICK_OPS.includes(filter.op)
-  );
-  const activeQuickOp = quickFilter?.filter.op ?? null;
+  // Each column can carry one quick filter from each conflict group
+  // (missing/not-missing, duplicated/unique) simultaneously, so the UI
+  // tracks the *set* of active quick ops rather than a single one.
+  // The four `ToggleItem` rows below light up independently from
+  // this set.
+  const activeQuickOps = useMemo(() => {
+    const out = new Set<FilterOp>();
+    for (const { filter } of columnFilters) {
+      if (QUICK_OPS.includes(filter.op)) out.add(filter.op);
+    }
+    return out;
+  }, [columnFilters]);
   const hasFilter = columnFilters.length > 0;
 
   const [menuOpen, setMenuOpen] = useState(false);
@@ -131,17 +146,22 @@ export function ColumnHeader({
 
   const toggleSort = (ascending: boolean) => {
     setMenuOpen(false);
-    if (activeSort && activeSort.ascending === ascending) {
-      applySort(null);
-    } else {
-      applySort({ columnIndex: column.index, ascending });
-    }
+    // Defer toggle/append/flip semantics to the store. Clicking the
+    // currently-active direction removes the entry; clicking the
+    // opposite flips it; clicking on a brand-new column appends at
+    // the end (next sort priority).
+    toggleSortStore({ columnIndex: column.index, ascending });
   };
 
   const toggleQuickFilter = (op: FilterOp) => {
     setMenuOpen(false);
-    if (activeQuickOp === op && quickFilter) {
-      removeFilterAt(quickFilter.idx);
+    // If this exact op is already active on this column → remove it.
+    // Otherwise add (and let the store evict only the *conflicting*
+    // op from the same group, leaving the other group's quick filter
+    // intact so missing+unique can coexist).
+    const existing = columnFilters.find(({ filter }) => filter.op === op);
+    if (existing) {
+      removeFilterAt(existing.idx);
     } else {
       addOrReplaceColumnFilter({ columnIndex: column.index, op });
     }
@@ -249,15 +269,25 @@ export function ColumnHeader({
             </button>
 
             <div className="kensa-col-menu-divider" />
-            <div className="kensa-col-menu-section">Sort</div>
+            <div className="kensa-col-menu-section">
+              Sort
+              {activeSort && activeSort.total > 1 && (
+                <span
+                  className="kensa-col-menu-section-badge"
+                  title={`Sort priority ${activeSort.priority} of ${activeSort.total}`}
+                >
+                  #{activeSort.priority}
+                </span>
+              )}
+            </div>
             <SortItem
-              active={activeSort?.ascending === true}
+              active={activeSort?.sort.ascending === true}
               label="Sort ascending"
               arrow="↑"
               onClick={() => toggleSort(true)}
             />
             <SortItem
-              active={activeSort?.ascending === false}
+              active={activeSort?.sort.ascending === false}
               label="Sort descending"
               arrow="↓"
               onClick={() => toggleSort(false)}
@@ -266,22 +296,22 @@ export function ColumnHeader({
             <div className="kensa-col-menu-divider" />
             <div className="kensa-col-menu-section">Quick filters</div>
             <ToggleItem
-              active={activeQuickOp === 'is_not_missing'}
+              active={activeQuickOps.has('is_not_missing')}
               label="Hide missing"
               onClick={() => toggleQuickFilter('is_not_missing')}
             />
             <ToggleItem
-              active={activeQuickOp === 'is_missing'}
+              active={activeQuickOps.has('is_missing')}
               label="Only missing"
               onClick={() => toggleQuickFilter('is_missing')}
             />
             <ToggleItem
-              active={activeQuickOp === 'is_duplicated'}
+              active={activeQuickOps.has('is_duplicated')}
               label="Only duplicates"
               onClick={() => toggleQuickFilter('is_duplicated')}
             />
             <ToggleItem
-              active={activeQuickOp === 'is_unique'}
+              active={activeQuickOps.has('is_unique')}
               label="Only unique values"
               onClick={() => toggleQuickFilter('is_unique')}
             />

--- a/src/webview/components/DataGrid.tsx
+++ b/src/webview/components/DataGrid.tsx
@@ -121,7 +121,7 @@ export function DataGrid({ slice: baseSlice }: DataGridProps) {
   const addFilter = useKensaStore((s) => s.addFilter);
   const activeFilters = useKensaStore((s) => s.activeFilters);
   const removeColumnFilter = useKensaStore((s) => s.removeColumnFilter);
-  const applySort = useKensaStore((s) => s.applySort);
+  const toggleSort = useKensaStore((s) => s.toggleSort);
 
   const writeClipboard = (text: string, successToast: { label: string; value?: string }) => {
     navigator.clipboard
@@ -498,7 +498,7 @@ export function DataGrid({ slice: baseSlice }: DataGridProps) {
             });
           }}
           onSort={(ascending) =>
-            applySort({ columnIndex: contextTarget.colIdx, ascending })
+            toggleSort({ columnIndex: contextTarget.colIdx, ascending })
           }
           onClearColumnFilters={() => removeColumnFilter(contextTarget.colIdx)}
           hasColumnFilters={activeFilters.some(

--- a/src/webview/components/Toolbar.tsx
+++ b/src/webview/components/Toolbar.tsx
@@ -34,7 +34,7 @@ export function Toolbar() {
   const source = useKensaStore((s) => s.source);
   const switching = useKensaStore((s) => s.switching);
   const activeFilters = useKensaStore((s) => s.activeFilters);
-  const activeSort = useKensaStore((s) => s.activeSort);
+  const activeSorts = useKensaStore((s) => s.activeSorts);
   const showSummaryPanel = useKensaStore((s) => s.showSummaryPanel);
   const showOperationsPanel = useKensaStore((s) => s.showOperationsPanel);
   const showCodePreview = useKensaStore((s) => s.showCodePreview);
@@ -47,7 +47,8 @@ export function Toolbar() {
   const rowCount = slice?.totalRows ?? 0;
   const colCount = slice?.columns.length ?? 0;
   const filterCount = activeFilters.length;
-  const hasView = filterCount > 0 || activeSort !== null;
+  const sortCount = activeSorts.length;
+  const hasView = filterCount > 0 || sortCount > 0;
 
   // Whole-dataset completeness — non-missing cells / total cells.
   //
@@ -134,17 +135,18 @@ export function Toolbar() {
             type="button"
             className="kensa-filter-badge"
             onClick={clearAllFilters}
-            title={
-              filterCount > 0
-                ? `${filterCount} filter${filterCount === 1 ? '' : 's'} active — click to clear all`
-                : 'Active sort — click to clear'
-            }
+            title={describeView(filterCount, sortCount)}
           >
             <FilterIcon size={14} />
             <span className="kensa-filter-badge-label">
               {filterCount > 0 ? (
                 <>
                   {filterCount} filter{filterCount === 1 ? '' : 's'}
+                  {sortCount > 0 && (
+                    <>
+                      {' '}· {sortCount} sort{sortCount === 1 ? '' : 's'}
+                    </>
+                  )}
                   {/* Filtered/total counter gives the user the "hit rate"
                       of their filter at a glance without opening the
                       summary panel. Omitted when only sort is active
@@ -154,7 +156,9 @@ export function Toolbar() {
                   </span>
                 </>
               ) : (
-                'Sorted'
+                <>
+                  {sortCount} sort{sortCount === 1 ? '' : 's'}
+                </>
               )}
             </span>
             <span className="kensa-filter-badge-close">×</span>
@@ -200,7 +204,19 @@ export function Toolbar() {
               ? 'Refresh from notebook variable'
               : 'Re-read file from disk'
           }
-          onClick={() => postMessage({ type: 'refreshSource' })}
+          // Ship the current view (filters + sorts) along with the
+          // refresh request. The extension reloads the underlying data
+          // — which resets the backend's view-state — and then re-
+          // applies these so the chip and the data shown stay in
+          // sync. Without this hand-off the backend would come back
+          // unfiltered while the webview UI still claimed it was.
+          onClick={() =>
+            postMessage({
+              type: 'refreshSource',
+              filters: activeFilters,
+              sorts: activeSorts
+            })
+          }
         >
           <RefreshIcon />
         </IconButton>
@@ -234,6 +250,20 @@ export function Toolbar() {
       </div>
     </div>
   );
+}
+
+/** Build the tooltip for the filter+sort chip. Reflects whichever
+ *  combination is active; "click to clear all" matches the chip's
+ *  click handler so the user knows what hitting × will undo. */
+function describeView(filterCount: number, sortCount: number): string {
+  const parts: string[] = [];
+  if (filterCount > 0) {
+    parts.push(`${filterCount} filter${filterCount === 1 ? '' : 's'}`);
+  }
+  if (sortCount > 0) {
+    parts.push(`${sortCount} sort key${sortCount === 1 ? '' : 's'}`);
+  }
+  return `${parts.join(' + ')} active — click to clear all`;
 }
 
 /** Search pill that jumps to a column by name match. Typing triggers a

--- a/src/webview/state/store.ts
+++ b/src/webview/state/store.ts
@@ -17,6 +17,23 @@ import type {
 } from '../../shared/types';
 import { postMessage } from '../vscodeApi';
 
+/** Quick-filter ops that can never coexist on the same column. The
+ *  groups are AND-disjoint — a single value cannot satisfy both. We
+ *  keep this here (rather than as a hardcoded list inside one action)
+ *  so the column-header UI can ALSO consult it when deciding which
+ *  toggle states to show as active for a given column. */
+const QUICK_OP_CONFLICT_GROUPS: ReadonlyArray<ReadonlyArray<FilterSpec['op']>> = [
+  ['is_missing', 'is_not_missing'],
+  ['is_duplicated', 'is_unique']
+];
+
+function quickOpConflicts(op: FilterSpec['op']): ReadonlyArray<FilterSpec['op']> {
+  for (const group of QUICK_OP_CONFLICT_GROUPS) {
+    if (group.includes(op)) return group;
+  }
+  return [];
+}
+
 export interface KensaState {
   // Server state
   slice: DataSlice | null;
@@ -51,8 +68,15 @@ export interface KensaState {
   // Active view: the sort + filter list currently applied to the grid. We
   // track them in the webview so the Toolbar can show a live count and
   // individual column headers can clear only their own filters.
+  //
+  // `activeSorts` is an ordered list, not a single sort, so users can
+  // build a multi-key sort (e.g. group by `region` ASC, then within
+  // each region order by `revenue` DESC). The order in the array is
+  // the priority — index 0 is the primary key. Empty array means
+  // unsorted. The single-sort code path was a hard limitation of the
+  // earlier design that this store now lifts.
   activeFilters: FilterSpec[];
-  activeSort: SortSpec | null;
+  activeSorts: SortSpec[];
 
   // UI state
   selectedColumn: number | null;
@@ -117,7 +141,22 @@ export interface KensaState {
   removeFilterAt: (index: number) => void;
   removeColumnFilter: (columnIndex: number) => void;
   clearAllFilters: () => void;
-  applySort: (sort: SortSpec | null) => void;
+
+  /** Toggle a sort on a column.
+   *  - If the column isn't already sorted, append it to `activeSorts`
+   *    at the lowest priority (so the user's first click is primary,
+   *    next click on a different column is secondary, etc.).
+   *  - If the column is already sorted in the same direction, remove
+   *    its entry (clicking "asc" twice clears the sort).
+   *  - If the column is already sorted in the opposite direction,
+   *    flip just that entry's direction in place (its priority slot
+   *    stays put). */
+  toggleSort: (sort: SortSpec) => void;
+  /** Drop the sort entry for one column without touching the others. */
+  removeSort: (columnIndex: number) => void;
+  /** Replace the entire sort list — used by the "clear all" path and
+   *  by message handlers that need to overwrite from outside. */
+  setSorts: (sorts: SortSpec[]) => void;
 
   setColumnSearchQuery: (q: string) => void;
   requestScrollToColumn: (name: string) => void;
@@ -140,7 +179,7 @@ export const useKensaStore = create<KensaState>((set) => ({
   switching: false,
   error: null,
   activeFilters: [],
-  activeSort: null,
+  activeSorts: [],
   columnSearchQuery: '',
   scrollToColumnToken: 0,
   scrollToColumnName: null,
@@ -218,7 +257,7 @@ export const useKensaStore = create<KensaState>((set) => ({
   setEngine: (engine) => set({ engine }),
   setSource: (source) =>
     // Changing source = new panel load — drop any stale filter/sort state.
-    set({ source, activeFilters: [], activeSort: null }),
+    set({ source, activeFilters: [], activeSorts: [] }),
   setFileName: (fileName) => set({ fileName }),
   setLoading: (loading) => set({ loading }),
   setSwitching: (switching) => set({ switching }),
@@ -235,23 +274,25 @@ export const useKensaStore = create<KensaState>((set) => ({
   toggleOperationsPanel: () => set((s) => ({ showOperationsPanel: !s.showOperationsPanel })),
   toggleCodePreview: () => set((s) => ({ showCodePreview: !s.showCodePreview })),
 
-  // Quick-filter ops (from the column menu) are mutually exclusive on
-  // the same column — selecting "Only missing" after "Only unique"
-  // replaces the earlier choice. Advanced-filter ops stack freely
-  // alongside the quick filter. The distinction lets a user combine
-  // "hide missing" (quick) with "contains 'foo'" (advanced) on one
-  // column, which the old single-filter-per-column semantics blocked.
+  // Quick-filter ops (from the column menu) split into two conflict
+  // groups; only ops in the SAME group evict each other on the same
+  // column.
+  //
+  //   Group A: is_missing  / is_not_missing  (a value can't be both)
+  //   Group B: is_duplicated / is_unique     (a value can't be both)
+  //
+  // Cross-group combinations stack freely, so a user can ask for
+  // "non-missing AND unique" on one column without losing one of the
+  // two when they apply the second. The previous version evicted ALL
+  // quick ops on the column whenever any quick op was applied, which
+  // forced the user to manually pick the more important constraint
+  // and silently dropped the other.
   addOrReplaceColumnFilter: (filter) =>
     set((s) => {
-      const QUICK_OPS: FilterSpec['op'][] = [
-        'is_missing',
-        'is_not_missing',
-        'is_duplicated',
-        'is_unique'
-      ];
+      const conflicts = quickOpConflicts(filter.op);
       const next = s.activeFilters.filter(
         (f) =>
-          !(f.columnIndex === filter.columnIndex && QUICK_OPS.includes(f.op))
+          !(f.columnIndex === filter.columnIndex && conflicts.includes(f.op))
       );
       next.push(filter);
       postMessage({ type: 'applyFilter', filters: next });
@@ -293,14 +334,42 @@ export const useKensaStore = create<KensaState>((set) => ({
   clearAllFilters: () =>
     set(() => {
       postMessage({ type: 'applyFilter', filters: [] });
-      postMessage({ type: 'applySort', sort: null });
-      return { activeFilters: [], activeSort: null };
+      postMessage({ type: 'applySort', sorts: [] });
+      return { activeFilters: [], activeSorts: [] };
     }),
 
-  applySort: (sort) =>
+  toggleSort: (sort) =>
+    set((s) => {
+      const existing = s.activeSorts.find((x) => x.columnIndex === sort.columnIndex);
+      let next: SortSpec[];
+      if (!existing) {
+        // First time we sort this column — append at lowest priority.
+        next = [...s.activeSorts, sort];
+      } else if (existing.ascending === sort.ascending) {
+        // Click the same direction the column is already sorted by →
+        // treat as a toggle and remove it from the sort list.
+        next = s.activeSorts.filter((x) => x.columnIndex !== sort.columnIndex);
+      } else {
+        // Different direction → flip in-place; priority slot stays put.
+        next = s.activeSorts.map((x) =>
+          x.columnIndex === sort.columnIndex ? sort : x
+        );
+      }
+      postMessage({ type: 'applySort', sorts: next });
+      return { activeSorts: next };
+    }),
+
+  removeSort: (columnIndex) =>
+    set((s) => {
+      const next = s.activeSorts.filter((x) => x.columnIndex !== columnIndex);
+      postMessage({ type: 'applySort', sorts: next });
+      return { activeSorts: next };
+    }),
+
+  setSorts: (sorts) =>
     set(() => {
-      postMessage({ type: 'applySort', sort });
-      return { activeSort: sort };
+      postMessage({ type: 'applySort', sorts });
+      return { activeSorts: sorts };
     }),
 
   setColumnSearchQuery: (q) => set({ columnSearchQuery: q }),

--- a/src/webview/styles/app.css
+++ b/src/webview/styles/app.css
@@ -866,6 +866,32 @@
   color: var(--kensa-text-subtle);
   padding: 6px 16px 4px;
   font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+/* Priority badge for the Sort section header — appears as `#2` next
+ * to the "Sort" label when this column is the secondary sort key in
+ * a multi-column sort, `#3` for the tertiary, etc. Hidden when the
+ * sort list has only one column or this column isn't sorted at all
+ * (controlled by the React component, not CSS). */
+.kensa-col-menu-section-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: var(--kensa-radius-pill);
+  background: var(--kensa-primary-soft);
+  color: var(--kensa-primary-strong);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: none;
+  font-variant-numeric: tabular-nums;
 }
 
 .kensa-col-menu-icon {

--- a/test/integration/engine.test.ts
+++ b/test/integration/engine.test.ts
@@ -74,8 +74,10 @@ test('Rust engine round-trip: load, slice, stats, sort, filter, export', { skip:
     const ageInsight = insights.find((i) => i.columnIndex === 1);
     assert.equal(ageInsight?.kind, 'numeric');
 
-    // Sort by age ascending puts missing (Carol) last
-    engine.sort(1, true);
+    // Sort by age ascending puts missing (Carol) last. The engine's
+    // sort API now takes a multi-key spec list; single-column sort is
+    // just a one-element list.
+    engine.sort([{ columnIndex: 1, ascending: true }]);
     const sorted = engine.getSlice(0, 10);
     assert.equal(sorted.rows[0]?.[0], 'Bob'); // 25
     assert.equal(sorted.rows[1]?.[0], 'Alice'); // 30
@@ -89,6 +91,16 @@ test('Rust engine round-trip: load, slice, stats, sort, filter, export', { skip:
     const filtered = engine.getSlice(0, 10);
     assert.equal(filtered.rows.length, 2);
     assert.ok(filtered.rows.every((r) => r[2] === 'NY'));
+
+    // Filter + sort now compose: applying a sort while a filter is
+    // active should keep the filter (the previous engine version wiped
+    // it). NY rows are Alice (30) and Dave (45); descending by age
+    // puts Dave first.
+    engine.sort([{ columnIndex: 1, ascending: false }]);
+    const filteredAndSorted = engine.getSlice(0, 10);
+    assert.equal(filteredAndSorted.rows.length, 2);
+    assert.equal(filteredAndSorted.rows[0]?.[0], 'Dave');
+    assert.equal(filteredAndSorted.rows[1]?.[0], 'Alice');
 
     // Substring search works against the current view order
     engine.resetView();


### PR DESCRIPTION
Pile of related fixes around the active-view state. Filter and sort were previously serialized into a single `view_indices` derivation in the Rust engine — applying a sort wiped the active filter and vice versa. Compound sorts weren't possible at all. And refreshing the data source dropped the backend's filter/sort state without telling the webview, leaving "1 filter active" chips on top of an unfiltered grid.

Engine: DataEngine now tracks active_filters and active_sorts separately, and `recompute_view` composes them on every change. New `sort_indices_multi` runs a stable composite sort over a (possibly filter-derived) indices vec, keyed on a priority list of (column, ascending) pairs. Filters are preserved across sort calls and vice versa. Single-key `sort_indices` is now `cfg(test)` since production goes through the multi-key path.

Wire: `applySort` now ships a `sorts: SortSpec[]` array. `refreshSource` optionally carries `filters` + `sorts` so the extension can re-apply the user's view to the freshly-loaded backend instead of letting them desync.

Python: STATE.view_sort -> view_sorts (list, priority order). Pandas `sort_values(by=[...], ascending=[...])` handles multi-key natively.

Webview state: activeSort: SortSpec|null -> activeSorts: SortSpec[]. New `toggleSort(spec)` action handles the per-column toggle/append/ flip semantics in one place. Stackable quick filters now allow one op from the missing/not-missing group plus one from the dup/unique group to coexist on the same column (was previously: any quick op evicted all others on the column, even compatible ones).

UI: Column header sort menu shows a `#N` priority badge when this column is part of a multi-key sort. Toolbar chip reads "2 filters · 3 sorts 1,234" instead of just "2 filters". Refresh icon now ships the current view along with the request.

Tests: 17 Rust (added multi_key_uses_secondary_as_tiebreaker), 51 TS (added filter+sort compose assertion in the engine integration test).