### PR TITLE
chore: release v0.1.13 — copy-row + case-insensitive filter fixes

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,6 +9,9 @@ src/shared/**
 # keep src/python/kensa_helpers.py — it's required at runtime
 !src/python/kensa_helpers.py
 !src/python/requirements.txt
+# Never ship compiled Python bytecode (created by any local py_compile /
+# import of the helpers — stale .pyc for the wrong interpreter version).
+**/__pycache__/**
 
 # Rust crate sources + intermediate target dir (the .node binary is copied
 # into crates/kensa-engine/ by napi build; we still need to include that).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to Kensa are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and Kensa follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.13] — 2026-07-06
+
+### Fixed
+
+- **Column ▾ menu sometimes did nothing when clicked.** Reverted the
+  JS-positioned (`position: fixed`) column menu introduced in 0.1.12
+  back to plain CSS anchoring. The JS variant's two-render handshake
+  (open → measure trigger → setState → render) could skip rendering
+  the menu entirely when the trigger ref hadn't populated before the
+  placement ran. The menu now renders synchronously on the same frame
+  as the open click. Tradeoff: on the rightmost columns of very
+  narrow windows the menu can clip at the viewport edge again —
+  accepted in exchange for the menu always opening.
+- **"Copy row" copied the wrong row after scrolling.** The row-number
+  click and the context menu's "Copy row (TSV)" computed the row's
+  position in the loaded window with page-aligned math, but slice
+  windows start at the first visible row, not at page boundaries.
+  After any scroll past the first page the copied data came from a
+  different row than the one clicked (or nothing copied at all).
+- **"Ignore case" was silently ignored in Edit mode.** Text filters
+  (equals / not-equals / contains / starts with / ends with / regex)
+  send a case-insensitive flag that the Rust viewing engine honors,
+  but the Python editing-mode path dropped it — the same filter
+  flipped to case-sensitive when switching View → Edit. The flag is
+  now forwarded over the wire and honored by the pandas view-filter
+  evaluation.
+
 ## [0.1.12] — 2026-05-10
 
 ### Added

--- a/crates/kensa-engine/Cargo.toml
+++ b/crates/kensa-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kensa-engine"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 license = "MIT"
 description = "Native data engine for Kensa — columnar CSV/Parquet/Excel reader and statistics kernel."

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kensa-viewer",
   "displayName": "Kensa",
   "description": "Visual tabular data exploration and cleaning for VS Code. Rust-powered viewer with optional Python/Pandas code-generating editor.",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "publisher": "AswinKithalawaarachchi",
   "license": "MIT",
   "preview": true,

--- a/src/extension/dataRouter.ts
+++ b/src/extension/dataRouter.ts
@@ -199,7 +199,8 @@ export class DataRouter {
     const payload = filters.map((f) => ({
       column: this.lastSlice?.columns[f.columnIndex]?.name ?? '',
       op: f.op,
-      value: f.value ?? ''
+      value: f.value ?? '',
+      caseInsensitive: f.caseInsensitive ?? false
     }));
     await backend.setViewFilters(payload);
   }

--- a/src/extension/pythonBackend.ts
+++ b/src/extension/pythonBackend.ts
@@ -209,7 +209,7 @@ export class PythonBackend {
    *  applied as steps, so clearing them (pass `[]`) instantly restores the
    *  previously-hidden rows. */
   async setViewFilters(
-    filters: Array<{ column: string; op: string; value?: string }>
+    filters: Array<{ column: string; op: string; value?: string; caseInsensitive?: boolean }>
   ): Promise<DataSlice> {
     return (await this.request({ cmd: 'set_view_filters', filters })) as DataSlice;
   }

--- a/src/python/kensa_helpers.py
+++ b/src/python/kensa_helpers.py
@@ -105,9 +105,25 @@ def _apply_view_filters(df: "pd.DataFrame", filters: List[Dict[str, Any]]) -> "p
         col = f.get("column")
         op = f.get("op")
         val = f.get("value")
+        # Sent by the webview for text ops; the Rust engine honors it, so
+        # the Python view path has to as well or the same filter flips
+        # behaviour when the user switches modes.
+        ci = bool(f.get("caseInsensitive"))
         if col is None or col not in df.columns:
             continue
         series = df[col]
+
+        def _text_and_val():
+            # Str-ified series + value for the text ops, folded to lower
+            # case when the filter asks for case-insensitive matching.
+            # Built on demand so numeric/missing ops skip the O(n)
+            # astype(str) conversion.
+            t = series.astype(str)
+            v = str(val)
+            if ci:
+                return t.str.lower(), v.lower()
+            return t, v
+
         try:
             if op == "is_missing":
                 m = series.isna()
@@ -118,9 +134,11 @@ def _apply_view_filters(df: "pd.DataFrame", filters: List[Dict[str, Any]]) -> "p
             elif op == "is_unique":
                 m = ~series.duplicated(keep=False) & series.notna()
             elif op == "eq":
-                m = series.astype(str) == str(val)
+                text, sval = _text_and_val()
+                m = text == sval
             elif op == "ne":
-                m = series.astype(str) != str(val)
+                text, sval = _text_and_val()
+                m = text != sval
             elif op == "gt":
                 m = pd.to_numeric(series, errors="coerce") > float(val)
             elif op == "gte":
@@ -130,13 +148,18 @@ def _apply_view_filters(df: "pd.DataFrame", filters: List[Dict[str, Any]]) -> "p
             elif op == "lte":
                 m = pd.to_numeric(series, errors="coerce") <= float(val)
             elif op == "contains":
-                m = series.astype(str).str.contains(str(val), na=False, regex=False)
+                text, sval = _text_and_val()
+                m = text.str.contains(sval, na=False, regex=False)
             elif op == "starts_with":
-                m = series.astype(str).str.startswith(str(val), na=False)
+                text, sval = _text_and_val()
+                m = text.str.startswith(sval, na=False)
             elif op == "ends_with":
-                m = series.astype(str).str.endswith(str(val), na=False)
+                text, sval = _text_and_val()
+                m = text.str.endswith(sval, na=False)
             elif op == "regex":
-                m = series.astype(str).str.contains(str(val), na=False, regex=True)
+                m = series.astype(str).str.contains(
+                    str(val), na=False, regex=True, case=not ci
+                )
             else:
                 continue
             mask = mask & m.fillna(False)

--- a/src/webview/components/DataGrid.tsx
+++ b/src/webview/components/DataGrid.tsx
@@ -136,8 +136,11 @@ export function DataGrid({ slice: baseSlice }: DataGridProps) {
   };
 
   const copyRowAt = (rowIdx: number): void => {
-    const pageStart = Math.floor(rowIdx / PAGE_SIZE) * PAGE_SIZE;
-    const localIdx = rowIdx - pageStart;
+    // The loaded window starts wherever the last pagination request began
+    // (`slice.startRow` is NOT page-aligned — requests use the first
+    // visible row), so the local index must be relative to startRow.
+    // The old page-aligned math copied the wrong row after any scroll.
+    const localIdx = rowIdx - slice.startRow;
     const row = slice.rows[localIdx];
     if (!row) return;
     const tsv = row


### PR DESCRIPTION
## Summary
Rolls up the fixes since 0.1.12 into the 0.1.13 release.

### Fixed
- **Copy row copied the wrong row after scrolling** — `copyRowAt` computed the local index with page-aligned math, but slice windows start at the first visible row. Now uses `rowIdx - slice.startRow`, matching the renderer.
- **"Ignore case" silently ignored in Edit mode** — the `caseInsensitive` flag was dropped between the webview and the pandas view-filter evaluation. Now forwarded end-to-end and honored by eq/ne/contains/starts_with/ends_with/regex, matching the Rust engine.
- (already on main) Column ▾ menu revert to CSS anchoring — documented in the 0.1.13 changelog entry.

### Release chores
- Bump `package.json` + `kensa-engine` crate to 0.1.13
- CHANGELOG entry for 0.1.13
- Exclude `__pycache__` from vsix packaging

## Verification
- `npm run typecheck` clean
- `npm test` — 60/60 pass
- `cargo test` — 17/17 pass
- `vsce package` — kensa-viewer-0.1.13.vsix, 21 files, 4.28 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)